### PR TITLE
Updated arc_executeCodeUnit, fn_broadcastCode

### DIFF
--- a/Addons/ares_zeusExtensions/functions/fn_BroadcastCode.sqf
+++ b/Addons/ares_zeusExtensions/functions/fn_BroadcastCode.sqf
@@ -8,16 +8,17 @@
 	Params:
 		0 - Code - The block of code to execute remotely.
 		1 - Anything - (Optional) The parameters to pass to the code. Default: [].
-		2 - Bool - (Optional) False if this should run only on the server, true if it should be run everywhere (including this machine). Default: true.
+		2 - Number - (Optional) 2 if this should run only on the server, 0 if it should be run everywhere (including this machine). Default: 0.
 */
 
-_codeBlock = [_this, 0] call BIS_fnc_Param;
-_params = [_this, 1, []] call BIS_fnc_Param;
-_runOnAllMachines = [_this, 2, true, [true]] call BIS_fnc_Param;
+_codeBlock = param [0];
+_params = param [1, []];
+_runOnAllMachines = param [2, 0, [0]]; // Will run on all machines
 
 Ares_oneshotCodeBlock = _codeBlock;
-publicVariable "Ares_oneshotCodeBlock";
+publicVariable "Ares_oneshotCodeBlock"; // May be redundant but not exactly a waste of space either.
 
-[_params, "Ares_oneshotCodeBlock", _runOnAllMachines] call BIS_fnc_MP;
+//[_params, "Ares_oneshotCodeBlock", _runOnAllMachines] call BIS_fnc_MP;
+_params remoteExecCall ["Ares_oneShotCodeBlock",_runOnAllMachines];
 
-true;
+true

--- a/Addons/ares_zeusExtensions/functions/fn_MakePlayerInvisible.sqf
+++ b/Addons/ares_zeusExtensions/functions/fn_MakePlayerInvisible.sqf
@@ -34,4 +34,4 @@ _updateVisibilityBlock = {
 		_unit hideObjectGlobal _shouldBeInvisible;
 	};
 };
-[_updateVisibilityBlock, [_unit, _shouldBeInvisible], true] call Ares_fnc_BroadcastCode;
+[_updateVisibilityBlock, [_unit, _shouldBeInvisible], 0] call Ares_fnc_BroadcastCode;

--- a/Addons/ares_zeusExtensions/scripts/ARC_MTAW_IgnoreCombat.sqf
+++ b/Addons/ares_zeusExtensions/scripts/ARC_MTAW_IgnoreCombat.sqf
@@ -8,12 +8,12 @@
 			if (isPlayer _unitUnderCursor) exitWith {
 				[objNull, "Can't place module on a player unit"] call BIS_fnc_showCuratorFeedbackMessage;
 			};
-			
+
 			[{
 				_group = group _this;
 				_index = currentWaypoint _group;
 				_dest = waypointPosition [_group, _index];
-				
+
 				{
 					[_x] joinSilent grpNull;
 					_grp = group _x;
@@ -29,7 +29,7 @@
 					[_x, _x] call ace_medical_fnc_treatmentAdvanced_fullHeal;
 					_x doMove _dest;
 				} forEach units _group;
-			}, _unitUnderCursor, true] call Ares_fnc_BroadcastCode;
+			}, _unitUnderCursor, 0] call Ares_fnc_BroadcastCode;
 		};
 	}
 ] call Ares_fnc_RegisterCustomModule;

--- a/Addons/ares_zeusExtensions/scripts/ARC_MTAW_ReturnFire.sqf
+++ b/Addons/ares_zeusExtensions/scripts/ARC_MTAW_ReturnFire.sqf
@@ -8,12 +8,12 @@
 			if (isPlayer _unitUnderCursor) exitWith {
 				[objNull, "Can't place module on a player unit"] call BIS_fnc_showCuratorFeedbackMessage;
 			};
-			
+
 			[{
 				_group = group _this;
 				_index = currentWaypoint _group;
 				_dest = waypointPosition [_group, _index];
-				
+
 				{
 					[_x] joinSilent grpNull;
 					_grp = group _x;
@@ -27,7 +27,7 @@
 					[_x, _x] call ace_medical_fnc_treatmentAdvanced_fullHeal;
 					_x doMove _dest;
 				} forEach units _group;
-			}, _unitUnderCursor, true] call Ares_fnc_BroadcastCode;
+			}, _unitUnderCursor, 0] call Ares_fnc_BroadcastCode;
 		};
 	}
 ] call Ares_fnc_RegisterCustomModule;

--- a/Addons/ares_zeusExtensions/scripts/ARC_executeCodeUnit.sqf
+++ b/Addons/ares_zeusExtensions/scripts/ARC_executeCodeUnit.sqf
@@ -17,9 +17,7 @@
 				
 				try {
 					_compiledText = compile _pastedText;
-					ARC_oneshotCodeBlock = _compiledText;
-					publicVariable "ARC_oneshotCodeBlock";
-                    [] remoteExecCall ["ARC_oneshotCodeBlock", _unitUnderCursor];
+					[_compiledText, _unitUnderCursor] call Ares_fnc_broadCastCode;
 				} catch {
 					diag_log _exception;
 					["Failed to parse code. See RPT for error."] call Ares_fnc_ShowZeusMessage;

--- a/Addons/ares_zeusExtensions/scripts/Util_DisableSimulation.sqf
+++ b/Addons/ares_zeusExtensions/scripts/Util_DisableSimulation.sqf
@@ -3,7 +3,7 @@
 	"Disable Simulation",
 	{
 		_unitUnderCursor = _this select 1;
-		
+
 		if (isNull _unitUnderCursor) then
 		{
 			["Module must be dropped on an object."] call Ares_fnc_ShowZeusMessage;
@@ -11,7 +11,7 @@
 		else
 		{
 			_codeBlock = {_this enableSimulationGlobal false;};
-			[_codeBlock, _unitUnderCursor, false] call Ares_fnc_BroadcastCode;
+			[_codeBlock, _unitUnderCursor, 2] call Ares_fnc_BroadcastCode;
 			["Simulation disabled."] call Ares_fnc_ShowZeusMessage;
 		};
 	}

--- a/Addons/ares_zeusExtensions/scripts/Util_EnableSimulation.sqf
+++ b/Addons/ares_zeusExtensions/scripts/Util_EnableSimulation.sqf
@@ -10,7 +10,7 @@
 		else
 		{
 			_codeBlock = {_this enableSimulationGlobal true;};
-			[_codeBlock, _unitUnderCursor, false] call Ares_fnc_BroadcastCode;
+			[_codeBlock, _unitUnderCursor, 2] call Ares_fnc_BroadcastCode;
 			["Simulation enabled."] call Ares_fnc_ShowZeusMessage;
 		};
 	}

--- a/Addons/ares_zeusExtensions/scripts/Util_ExecuteCodeAll.sqf
+++ b/Addons/ares_zeusExtensions/scripts/Util_ExecuteCodeAll.sqf
@@ -6,7 +6,7 @@
 		{
 			["This module has been disabled by the mission creator."] call Ares_fnc_ShowZeusMessage;
 		};
-	
+
 		missionNamespace setVariable ['Ares_CopyPaste_Dialog_Text', ""];
 		missionNamespace setVariable ["Ares_CopyPaste_Dialog_Result", ""];
 		_dialog = createDialog "Ares_CopyPaste_Dialog";
@@ -18,7 +18,7 @@
 			_pastedText = missionNamespace getVariable ["Ares_CopyPaste_Dialog_Text", "[]"];
 			try
 			{
-				[(compile _pastedText), _this, true] call Ares_fnc_BroadcastCode;
+				[(compile _pastedText), _this, 0] call Ares_fnc_BroadcastCode;
 			}
 			catch
 			{

--- a/Addons/ares_zeusExtensions/scripts/Util_ExecuteCodeServer.sqf
+++ b/Addons/ares_zeusExtensions/scripts/Util_ExecuteCodeServer.sqf
@@ -18,7 +18,7 @@
 			_pastedText = missionNamespace getVariable ["Ares_CopyPaste_Dialog_Text", "[]"];
 			try
 			{
-				[(compile _pastedText), _this, false] call Ares_fnc_BroadcastCode;
+				[(compile _pastedText), _this, 2] call Ares_fnc_BroadcastCode;
 			}
 			catch
 			{


### PR DESCRIPTION
When merged this PR will:
- Update arc_executeCodeUnit to enable users to use _this as reference to _unitUnderCursor.
- Update fn_broadcastCode to use param and remoteExecCall instead of BIS_fnc_param and BIS_fnc_MP
- Update fn_makePlayerInvisible to reflect new usage of fn_broadCastCode (0/2 instead of true/false)

Missing:
- Might be more functions that use old fn_broadcastCode which need updating. I broke backwards compatibility, shoot me
- Some functions and scripts still use BIS_fnc_param / BIS_fnc_MP that need to be migrated over to param / remoteExecCall when we can be bothered.
